### PR TITLE
Improves undo to show last asset

### DIFF
--- a/plan/002-undo-zeigt-letztes-asset-wieder.md
+++ b/plan/002-undo-zeigt-letztes-asset-wieder.md
@@ -1,0 +1,21 @@
+# Plan: Undo/Redo zeigt letztes Asset wieder
+
+## Ziel
+- Beim Klick auf **Undo / Wiederherstellen** (oder `Ctrl+Z`) soll das zuletzt gelöschte Foto/Video nicht nur in Immich wiederhergestellt werden, sondern **auch wieder als aktuelles Asset angezeigt** werden, damit man erneut entscheiden kann (Keep/Delete).
+
+## Verhalten (Soll)
+1. User löscht Asset **A** → App zeigt anschließend Asset **B**.
+2. User drückt **Undo/Wiederherstellen** → Asset **A** wird restored und **sofort wieder angezeigt**.
+3. Nach der erneuten Entscheidung über **A** soll die App sinnvoll weitergehen (idealerweise zurück zu **B**).
+
+## Umsetzung (Tech)
+- `src/composables/useImmich.ts`
+  - `lastDeletedAsset` bleibt Quelle für den Undo.
+  - Beim Undo wird das aktuell angezeigte Asset als „Resume“-Kandidat zwischengespeichert und als `nextAsset` eingeplant.
+  - Nach erfolgreichem Restore: `currentAsset = restoredAsset`, `nextAsset = resumeAsset` (falls vorhanden).
+
+## Akzeptanzkriterien
+- Undo stellt das zuletzt gelöschte Asset wieder her **und** zeigt es erneut an.
+- Danach kann das Asset erneut per Swipe/Buttons entschieden werden.
+- Zähler/Toast bleiben konsistent (Deleted Count wird zurückgesetzt um 1).
+


### PR DESCRIPTION
Improves the undo functionality to restore and immediately display the last deleted asset.

This change ensures that after an undo operation, the restored asset is not only recovered but also presented to the user for immediate interaction (keep or delete), improving workflow.

- Adds a helper function `setCurrentAssetWithFallback` to handle setting the current asset and determining the next asset to display.
- Modifies the undo logic to store the currently displayed asset as a "resume" candidate, ensuring a smooth transition after the restored asset is handled.